### PR TITLE
Document v2 migration and allow Optim 2

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -14,7 +14,7 @@ StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 
 [compat]
 Distributions = "0.2, 0.25"
-Optim = "1, 1.4"
+Optim = "1, 2"
 Optimization = "3,4,5"
 julia = "1.10"
 RecipesBase = "1"

--- a/README.md
+++ b/README.md
@@ -23,10 +23,18 @@ The script to produce these plots is in `scripts/run_benchmark.jl`.
 
 ### Functions
 
-Functions with input dimension N can be generated using `bbob_suite()`:
+Functions with input dimension `N` can be generated using `bbob_suite`. Generate
+the suite once and index it by the BBOB function number:
 
 ```julia
-julia> BlackBoxOptimizationBenchmarking.bbob_suite(Val(2))
+julia> using BlackBoxOptimizationBenchmarking
+
+julia> suite = bbob_suite(Val(2));
+
+julia> suite[1]
+F1  Sphere
+
+julia> suite
 20-element Vector{BBOBFunction}:
  F1  Sphere
  F2  Ellipsoidal
@@ -50,7 +58,29 @@ julia> BlackBoxOptimizationBenchmarking.bbob_suite(Val(2))
  F20 Schwefel
  ```
 
-An indivdual `BBOBFunction` function `f`  has fields `f_opt` its minimal value, and `x_opt` its minimizer, i.e. `f(x_opt) = f_opt`.
+The index is the function number, so `suite[3]` is F3 (Rastrigin), for example.
+An individual `BBOBFunction` `f` has fields `f_opt`, its minimum value, and `x_opt`, its minimizer, i.e. `f(f.x_opt) == f.f_opt`.
+
+#### Migrating from v1
+
+In v1, functions were accessed from a global collection and accepted inputs of different dimensions. In v2, each function contains dimension-specific static vectors and rotation matrices. Create a suite for the required dimension and replace global lookups as follows:
+
+```julia
+# v1
+f = BlackBoxOptimizationBenchmarking.BBOBFunctions[3]
+
+# v2
+suite = BlackBoxOptimizationBenchmarking.bbob_suite(Val(5))
+f = suite[3]
+```
+
+Keep `suite` and reuse it rather than regenerating it for every function call. The optional seed selects a reproducible BBOB instance:
+
+```julia
+suite = bbob_suite(Val(5); seed = 123)
+```
+
+Changing the dimension requires generating another suite. This dimension-specific API is what allows the functions to use static arrays and run on GPUs.
 
 Functions can be plot using :
 

--- a/src/BlackBoxOptimizationBenchmarking.jl
+++ b/src/BlackBoxOptimizationBenchmarking.jl
@@ -4,8 +4,8 @@ module BlackBoxOptimizationBenchmarking
     using StaticArrays, Random
     using LinearAlgebra, RecipesBase
 
-    import Optim: minimum, minimizer
-    import Base: show
+    import Optim: minimizer
+    import Base: minimum, show
 
     export BBOBFunction, BenchmarkSetup, bbob_suite
     

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -9,6 +9,14 @@ using OptimizationBBO, OptimizationOptimJL
 
 test_functions = BBOB.bbob_suite(Val(3))
 
+@testset "Suite access" begin
+    @test length(test_functions) == 20
+    @test test_functions[3] isa BBOB.BBOBFunction
+    @test length(test_functions[3].x_opt) == 3
+    @test BBOB.bbob_suite(Val(3); seed=123)[3].x_opt ==
+          BBOB.bbob_suite(Val(3); seed=123)[3].x_opt
+end
+
 @testset "Function optima" begin
     for f in test_functions
         @test f(f.x_opt) ≈ f.f_opt atol=1e-5

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -13,6 +13,7 @@ test_functions = BBOB.bbob_suite(Val(3))
     @test length(test_functions) == 20
     @test test_functions[3] isa BBOB.BBOBFunction
     @test length(test_functions[3].x_opt) == 3
+    @test minimum(test_functions[3]) == test_functions[3].f_opt
     @test BBOB.bbob_suite(Val(3); seed=123)[3].x_opt ==
           BBOB.bbob_suite(Val(3); seed=123)[3].x_opt
 end


### PR DESCRIPTION
1. Document migration from `BBOBFunctions` to `bbob_suite(Val(N))`
2. Allow Optim 1 and 2
3. Add tests for suite access and reproducibility